### PR TITLE
Add cholmod long patch from master

### DIFF
--- a/recipe/0001-cholmod_support.patch
+++ b/recipe/0001-cholmod_support.patch
@@ -1,0 +1,347 @@
+diff --git a/Eigen/src/CholmodSupport/CholmodSupport.h b/Eigen/src/CholmodSupport/CholmodSupport.h
+index 571972023..adaf52858 100644
+--- a/Eigen/src/CholmodSupport/CholmodSupport.h
++++ b/Eigen/src/CholmodSupport/CholmodSupport.h
+@@ -10,7 +10,7 @@
+ #ifndef EIGEN_CHOLMODSUPPORT_H
+ #define EIGEN_CHOLMODSUPPORT_H
+ 
+-namespace Eigen { 
++namespace Eigen {
+ 
+ namespace internal {
+ 
+@@ -32,7 +32,7 @@ template<> struct cholmod_configure_matrix<std::complex<double> > {
+   }
+ };
+ 
+-// Other scalar types are not yet suppotred by Cholmod
++// Other scalar types are not yet supported by Cholmod
+ // template<> struct cholmod_configure_matrix<float> {
+ //   template<typename CholmodType>
+ //   static void run(CholmodType& mat) {
+@@ -79,12 +79,12 @@ cholmod_sparse viewAsCholmod(Ref<SparseMatrix<_Scalar,_Options,_StorageIndex> >
+ 
+   res.dtype   = 0;
+   res.stype   = -1;
+-  
++
+   if (internal::is_same<_StorageIndex,int>::value)
+   {
+     res.itype = CHOLMOD_INT;
+   }
+-  else if (internal::is_same<_StorageIndex,long>::value)
++  else if (internal::is_same<_StorageIndex,SuiteSparse_long>::value)
+   {
+     res.itype = CHOLMOD_LONG;
+   }
+@@ -95,9 +95,9 @@ cholmod_sparse viewAsCholmod(Ref<SparseMatrix<_Scalar,_Options,_StorageIndex> >
+ 
+   // setup res.xtype
+   internal::cholmod_configure_matrix<_Scalar>::run(res);
+-  
++
+   res.stype = 0;
+-  
++
+   return res;
+ }
+ 
+@@ -121,9 +121,12 @@ template<typename _Scalar, int _Options, typename _Index, unsigned int UpLo>
+ cholmod_sparse viewAsCholmod(const SparseSelfAdjointView<const SparseMatrix<_Scalar,_Options,_Index>, UpLo>& mat)
+ {
+   cholmod_sparse res = viewAsCholmod(Ref<SparseMatrix<_Scalar,_Options,_Index> >(mat.matrix().const_cast_derived()));
+-  
++
+   if(UpLo==Upper) res.stype =  1;
+   if(UpLo==Lower) res.stype = -1;
++  // swap stype for rowmajor matrices (only works for real matrices)
++  EIGEN_STATIC_ASSERT((_Options & RowMajorBit) == 0 || NumTraits<_Scalar>::IsComplex == 0, THIS_METHOD_IS_ONLY_FOR_COLUMN_MAJOR_MATRICES);
++  if(_Options & RowMajorBit) res.stype *=-1;
+ 
+   return res;
+ }
+@@ -159,6 +162,44 @@ MappedSparseMatrix<Scalar,Flags,StorageIndex> viewAsEigen(cholmod_sparse& cm)
+           static_cast<StorageIndex*>(cm.p), static_cast<StorageIndex*>(cm.i),static_cast<Scalar*>(cm.x) );
+ }
+ 
++namespace internal {
++
++// template specializations for int and long that call the correct cholmod method
++
++#define EIGEN_CHOLMOD_SPECIALIZE0(ret, name) \
++    template<typename _StorageIndex> inline ret cm_ ## name       (cholmod_common &Common) { return cholmod_ ## name   (&Common); } \
++    template<>                       inline ret cm_ ## name<SuiteSparse_long> (cholmod_common &Common) { return cholmod_l_ ## name (&Common); }
++
++#define EIGEN_CHOLMOD_SPECIALIZE1(ret, name, t1, a1) \
++    template<typename _StorageIndex> inline ret cm_ ## name       (t1& a1, cholmod_common &Common) { return cholmod_ ## name   (&a1, &Common); } \
++    template<>                       inline ret cm_ ## name<SuiteSparse_long> (t1& a1, cholmod_common &Common) { return cholmod_l_ ## name (&a1, &Common); }
++
++EIGEN_CHOLMOD_SPECIALIZE0(int, start)
++EIGEN_CHOLMOD_SPECIALIZE0(int, finish)
++
++EIGEN_CHOLMOD_SPECIALIZE1(int, free_factor, cholmod_factor*, L)
++EIGEN_CHOLMOD_SPECIALIZE1(int, free_dense,  cholmod_dense*,  X)
++EIGEN_CHOLMOD_SPECIALIZE1(int, free_sparse, cholmod_sparse*, A)
++
++EIGEN_CHOLMOD_SPECIALIZE1(cholmod_factor*, analyze, cholmod_sparse, A)
++
++template<typename _StorageIndex> inline cholmod_dense*  cm_solve         (int sys, cholmod_factor& L, cholmod_dense&  B, cholmod_common &Common) { return cholmod_solve     (sys, &L, &B, &Common); }
++template<>                       inline cholmod_dense*  cm_solve<SuiteSparse_long>   (int sys, cholmod_factor& L, cholmod_dense&  B, cholmod_common &Common) { return cholmod_l_solve   (sys, &L, &B, &Common); }
++
++template<typename _StorageIndex> inline cholmod_sparse* cm_spsolve       (int sys, cholmod_factor& L, cholmod_sparse& B, cholmod_common &Common) { return cholmod_spsolve   (sys, &L, &B, &Common); }
++template<>                       inline cholmod_sparse* cm_spsolve<SuiteSparse_long> (int sys, cholmod_factor& L, cholmod_sparse& B, cholmod_common &Common) { return cholmod_l_spsolve (sys, &L, &B, &Common); }
++
++template<typename _StorageIndex>
++inline int  cm_factorize_p       (cholmod_sparse*  A, double beta[2], _StorageIndex* fset, std::size_t fsize, cholmod_factor* L, cholmod_common &Common) { return cholmod_factorize_p   (A, beta, fset, fsize, L, &Common); }
++template<>
++inline int  cm_factorize_p<SuiteSparse_long> (cholmod_sparse*  A, double beta[2], SuiteSparse_long* fset,          std::size_t fsize, cholmod_factor* L, cholmod_common &Common) { return cholmod_l_factorize_p (A, beta, fset, fsize, L, &Common); }
++
++#undef EIGEN_CHOLMOD_SPECIALIZE0
++#undef EIGEN_CHOLMOD_SPECIALIZE1
++
++}  // namespace internal
++
++
+ enum CholmodMode {
+   CholmodAuto, CholmodSimplicialLLt, CholmodSupernodalLLt, CholmodLDLt
+ };
+@@ -195,7 +236,7 @@ class CholmodBase : public SparseSolverBase<Derived>
+     {
+       EIGEN_STATIC_ASSERT((internal::is_same<double,RealScalar>::value), CHOLMOD_SUPPORTS_DOUBLE_PRECISION_ONLY);
+       m_shiftOffset[0] = m_shiftOffset[1] = 0.0;
+-      cholmod_start(&m_cholmod);
++      internal::cm_start<StorageIndex>(m_cholmod);
+     }
+ 
+     explicit CholmodBase(const MatrixType& matrix)
+@@ -203,23 +244,23 @@ class CholmodBase : public SparseSolverBase<Derived>
+     {
+       EIGEN_STATIC_ASSERT((internal::is_same<double,RealScalar>::value), CHOLMOD_SUPPORTS_DOUBLE_PRECISION_ONLY);
+       m_shiftOffset[0] = m_shiftOffset[1] = 0.0;
+-      cholmod_start(&m_cholmod);
++      internal::cm_start<StorageIndex>(m_cholmod);
+       compute(matrix);
+     }
+ 
+     ~CholmodBase()
+     {
+       if(m_cholmodFactor)
+-        cholmod_free_factor(&m_cholmodFactor, &m_cholmod);
+-      cholmod_finish(&m_cholmod);
++        internal::cm_free_factor<StorageIndex>(m_cholmodFactor, m_cholmod);
++      internal::cm_finish<StorageIndex>(m_cholmod);
+     }
+-    
++
+     inline StorageIndex cols() const { return internal::convert_index<StorageIndex, Index>(m_cholmodFactor->n); }
+     inline StorageIndex rows() const { return internal::convert_index<StorageIndex, Index>(m_cholmodFactor->n); }
+-    
++
+     /** \brief Reports whether previous computation was successful.
+       *
+-      * \returns \c Success if computation was succesful,
++      * \returns \c Success if computation was successful,
+       *          \c NumericalIssue if the matrix.appears to be negative.
+       */
+     ComputationInfo info() const
+@@ -235,29 +276,29 @@ class CholmodBase : public SparseSolverBase<Derived>
+       factorize(matrix);
+       return derived();
+     }
+-    
++
+     /** Performs a symbolic decomposition on the sparsity pattern of \a matrix.
+       *
+       * This function is particularly useful when solving for several problems having the same structure.
+-      * 
++      *
+       * \sa factorize()
+       */
+     void analyzePattern(const MatrixType& matrix)
+     {
+       if(m_cholmodFactor)
+       {
+-        cholmod_free_factor(&m_cholmodFactor, &m_cholmod);
++        internal::cm_free_factor<StorageIndex>(m_cholmodFactor, m_cholmod);
+         m_cholmodFactor = 0;
+       }
+       cholmod_sparse A = viewAsCholmod(matrix.template selfadjointView<UpLo>());
+-      m_cholmodFactor = cholmod_analyze(&A, &m_cholmod);
+-      
++      m_cholmodFactor = internal::cm_analyze<StorageIndex>(A, m_cholmod);
++
+       this->m_isInitialized = true;
+       this->m_info = Success;
+       m_analysisIsOk = true;
+       m_factorizationIsOk = false;
+     }
+-    
++
+     /** Performs a numeric decomposition of \a matrix
+       *
+       * The given matrix must have the same sparsity pattern as the matrix on which the symbolic decomposition has been performed.
+@@ -268,17 +309,17 @@ class CholmodBase : public SparseSolverBase<Derived>
+     {
+       eigen_assert(m_analysisIsOk && "You must first call analyzePattern()");
+       cholmod_sparse A = viewAsCholmod(matrix.template selfadjointView<UpLo>());
+-      cholmod_factorize_p(&A, m_shiftOffset, 0, 0, m_cholmodFactor, &m_cholmod);
++      internal::cm_factorize_p<StorageIndex>(&A, m_shiftOffset, 0, 0, m_cholmodFactor, m_cholmod);
+ 
+       // If the factorization failed, minor is the column at which it did. On success minor == n.
+       this->m_info = (m_cholmodFactor->minor == m_cholmodFactor->n ? Success : NumericalIssue);
+       m_factorizationIsOk = true;
+     }
+-    
++
+     /** Returns a reference to the Cholmod's configuration structure to get a full control over the performed operations.
+      *  See the Cholmod user guide for details. */
+     cholmod_common& cholmod() { return m_cholmod; }
+-    
++
+     #ifndef EIGEN_PARSED_BY_DOXYGEN
+     /** \internal */
+     template<typename Rhs,typename Dest>
+@@ -288,22 +329,23 @@ class CholmodBase : public SparseSolverBase<Derived>
+       const Index size = m_cholmodFactor->n;
+       EIGEN_UNUSED_VARIABLE(size);
+       eigen_assert(size==b.rows());
+-      
+-      // Cholmod needs column-major stoarge without inner-stride, which corresponds to the default behavior of Ref.
++
++      // Cholmod needs column-major storage without inner-stride, which corresponds to the default behavior of Ref.
+       Ref<const Matrix<typename Rhs::Scalar,Dynamic,Dynamic,ColMajor> > b_ref(b.derived());
+ 
+       cholmod_dense b_cd = viewAsCholmod(b_ref);
+-      cholmod_dense* x_cd = cholmod_solve(CHOLMOD_A, m_cholmodFactor, &b_cd, &m_cholmod);
++      cholmod_dense* x_cd = internal::cm_solve<StorageIndex>(CHOLMOD_A, *m_cholmodFactor, b_cd, m_cholmod);
+       if(!x_cd)
+       {
+         this->m_info = NumericalIssue;
+         return;
+       }
+       // TODO optimize this copy by swapping when possible (be careful with alignment, etc.)
++      // NOTE Actually, the copy can be avoided by calling cholmod_solve2 instead of cholmod_solve
+       dest = Matrix<Scalar,Dest::RowsAtCompileTime,Dest::ColsAtCompileTime>::Map(reinterpret_cast<Scalar*>(x_cd->x),b.rows(),b.cols());
+-      cholmod_free_dense(&x_cd, &m_cholmod);
++      internal::cm_free_dense<StorageIndex>(x_cd, m_cholmod);
+     }
+-    
++
+     /** \internal */
+     template<typename RhsDerived, typename DestDerived>
+     void _solve_impl(const SparseMatrixBase<RhsDerived> &b, SparseMatrixBase<DestDerived> &dest) const
+@@ -316,19 +358,20 @@ class CholmodBase : public SparseSolverBase<Derived>
+       // note: cs stands for Cholmod Sparse
+       Ref<SparseMatrix<typename RhsDerived::Scalar,ColMajor,typename RhsDerived::StorageIndex> > b_ref(b.const_cast_derived());
+       cholmod_sparse b_cs = viewAsCholmod(b_ref);
+-      cholmod_sparse* x_cs = cholmod_spsolve(CHOLMOD_A, m_cholmodFactor, &b_cs, &m_cholmod);
++      cholmod_sparse* x_cs = internal::cm_spsolve<StorageIndex>(CHOLMOD_A, *m_cholmodFactor, b_cs, m_cholmod);
+       if(!x_cs)
+       {
+         this->m_info = NumericalIssue;
+         return;
+       }
+       // TODO optimize this copy by swapping when possible (be careful with alignment, etc.)
++      // NOTE cholmod_spsolve in fact just calls the dense solver for blocks of 4 columns at a time (similar to Eigen's sparse solver)
+       dest.derived() = viewAsEigen<typename DestDerived::Scalar,ColMajor,typename DestDerived::StorageIndex>(*x_cs);
+-      cholmod_free_sparse(&x_cs, &m_cholmod);
++      internal::cm_free_sparse<StorageIndex>(x_cs, m_cholmod);
+     }
+     #endif // EIGEN_PARSED_BY_DOXYGEN
+-    
+-    
++
++
+     /** Sets the shift parameter that will be used to adjust the diagonal coefficients during the numerical factorization.
+       *
+       * During the numerical factorization, an offset term is added to the diagonal coefficients:\n
+@@ -343,7 +386,7 @@ class CholmodBase : public SparseSolverBase<Derived>
+       m_shiftOffset[0] = double(offset);
+       return derived();
+     }
+-    
++
+     /** \returns the determinant of the underlying matrix from the current factorization */
+     Scalar determinant() const
+     {
+@@ -398,7 +441,7 @@ class CholmodBase : public SparseSolverBase<Derived>
+     template<typename Stream>
+     void dumpMemory(Stream& /*s*/)
+     {}
+-    
++
+   protected:
+     mutable cholmod_common m_cholmod;
+     cholmod_factor* m_cholmodFactor;
+@@ -435,11 +478,11 @@ class CholmodSimplicialLLT : public CholmodBase<_MatrixType, _UpLo, CholmodSimpl
+ {
+     typedef CholmodBase<_MatrixType, _UpLo, CholmodSimplicialLLT> Base;
+     using Base::m_cholmod;
+-    
++
+   public:
+-    
++
+     typedef _MatrixType MatrixType;
+-    
++
+     CholmodSimplicialLLT() : Base() { init(); }
+ 
+     CholmodSimplicialLLT(const MatrixType& matrix) : Base()
+@@ -486,11 +529,11 @@ class CholmodSimplicialLDLT : public CholmodBase<_MatrixType, _UpLo, CholmodSimp
+ {
+     typedef CholmodBase<_MatrixType, _UpLo, CholmodSimplicialLDLT> Base;
+     using Base::m_cholmod;
+-    
++
+   public:
+-    
++
+     typedef _MatrixType MatrixType;
+-    
++
+     CholmodSimplicialLDLT() : Base() { init(); }
+ 
+     CholmodSimplicialLDLT(const MatrixType& matrix) : Base()
+@@ -535,11 +578,11 @@ class CholmodSupernodalLLT : public CholmodBase<_MatrixType, _UpLo, CholmodSuper
+ {
+     typedef CholmodBase<_MatrixType, _UpLo, CholmodSupernodalLLT> Base;
+     using Base::m_cholmod;
+-    
++
+   public:
+-    
++
+     typedef _MatrixType MatrixType;
+-    
++
+     CholmodSupernodalLLT() : Base() { init(); }
+ 
+     CholmodSupernodalLLT(const MatrixType& matrix) : Base()
+@@ -586,11 +629,11 @@ class CholmodDecomposition : public CholmodBase<_MatrixType, _UpLo, CholmodDecom
+ {
+     typedef CholmodBase<_MatrixType, _UpLo, CholmodDecomposition> Base;
+     using Base::m_cholmod;
+-    
++
+   public:
+-    
++
+     typedef _MatrixType MatrixType;
+-    
++
+     CholmodDecomposition() : Base() { init(); }
+ 
+     CholmodDecomposition(const MatrixType& matrix) : Base()
+@@ -600,7 +643,7 @@ class CholmodDecomposition : public CholmodBase<_MatrixType, _UpLo, CholmodDecom
+     }
+ 
+     ~CholmodDecomposition() {}
+-    
++
+     void setMode(CholmodMode mode)
+     {
+       switch(mode)
+
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-cholmod_support.patch    
 
 build:
-  number: 1001
+  number: 1002
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,10 @@ source:
   fn: eigen-{{ version }}.tar.gz
   url: http://bitbucket.org/eigen/eigen/get/{{ version }}.tar.gz
   sha256: 7e84ef87a07702b54ab3306e77cea474f56a40afa1c0ab245bb11725d006d0da
+  {% if version == "3.3.7" %}
   patches:
-    - 0001-cholmod_support.patch    
+    - 0001-cholmod_support.patch
+  {% endif %}
 
 build:
   number: 1002

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ source:
   fn: eigen-{{ version }}.tar.gz
   url: http://bitbucket.org/eigen/eigen/get/{{ version }}.tar.gz
   sha256: 7e84ef87a07702b54ab3306e77cea474f56a40afa1c0ab245bb11725d006d0da
+  patches:
+    - 0001-cholmod_support.patch    
 
 build:
   number: 1001


### PR DESCRIPTION
Checklist
* [X] Used a fork of the feedstock to propose changes
* [X] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This adds better cholmod support for longs via the SuiteSparse_long macro, which is on the master branch of the eigen project. The main commit from this patch has the following message:

> SuiteSparse defines the macro SuiteSparse_long to control what type is used for 64bit integers. The default value of this macro on non-MSVC platforms is long and __int64 on MSVC. CholmodSupport defaults to using long for the long variants of CHOLMOD functions. This creates problems when SuiteSparse_long is different than long. So the correct thing to do here is to use SuiteSparse_long as the type instead of long.

We've been using this for a few years now, waiting for an eigen 3.4 release with this patch, but the project is moving slow on that release.