### PR TITLE
Add run_constraints on eigen version in eigen-abi

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,7 +12,7 @@ source:
     sha256: 8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - package:
@@ -99,6 +99,9 @@ outputs:
       name: eigen-abi
       # The version of eigen-abi is composed by the eigen version, and eigen_abi_profile value
       version: ${{ version }}.${{ eigen_abi_profile }}
+    requirements:
+      run_constraints:
+        - ${{ pin_subpackage('eigen', upper_bound='x.x.x') }}
     tests:
       - script:
           - echo "This is a metapackage, no test is necessary."


### PR DESCRIPTION
In https://github.com/conda-forge/eigen-feedstock/pull/49 there was a split between `eigen-abi` (the marker package that indicates the specific variant of Eigen ABI used for all packages in the conda environment) and `eigen-abi-devel`, used when building a package that is consuming the Eigen ABI. 

This was done to avoid that just installing a packages that uses the `eigen-abi` result in installing an unwanted `x86_64-microarch-level`, unless the Eigen ABI is explicitly targeted.

However, I think it is extremely useful to avoid mismatch in Eigen version (leaving aside microarch-optimized packages, that is minimal fraction of packages for now) to have a `run_constraints` in `eigen-abi` on the `eigen` version. 

At least, this is something that would save a lot for work as part of https://github.com/conda-forge/eigen-feedstock/issues/52 . 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
