### PR TITLE
[ci skip] Change project homepage URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About eigen-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/eigen-feedstock/blob/main/LICENSE.txt)
 
-Home: http://eigen.tuxfamily.org/
+Home: https://libeigen.gitlab.io/
 
 Package license: MPL-2.0
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -120,7 +120,7 @@ outputs:
 
 
 about:
-  homepage: http://eigen.tuxfamily.org/
+  homepage: https://libeigen.gitlab.io/
   license: MPL-2.0
   license_file: COPYING.MPL2
   summary: C++ template library for linear algebra


### PR DESCRIPTION
Eigen's docs are now hosted on gitlab.io instead of the rather shaky tuxfamily page (there's currently a redirection 😄 )

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
